### PR TITLE
Prototype pollution fix: Avoid setting magic attributes

### DIFF
--- a/packages/convict/src/main.js
+++ b/packages/convict/src/main.js
@@ -559,6 +559,11 @@ const convict = function convict(def, opts) {
     set: function(k, v) {
       v = coerce(k, v, this._schema, this)
       const path = k.split('.')
+      if (['__proto__', 'prototype', 'constructor'].some(function(key) {
+        return path.indexOf(key) !== -1;
+      })) {
+        return this;
+      }
       const childKey = path.pop()
       const parentKey = path.join('.')
       const parent = walk(this._instance, parentKey, true)


### PR DESCRIPTION
### 📊 Metadata *

`convict` is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-convict/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

`// poc.js`
`var convict = require("convict");`
`var obj = {};`
`var config = convict(obj);`
`console.log("Before : " + {}.polluted);`
`config.set("__proto__.polluted","Yes! Its Polluted");`
`console.log("After : " + {}.polluted);`

Execute the following commands in another terminal:

`npm i convict # Install affected module`
`node poc.js #  Run the PoC`

Check the Output:

`Before : undefined`
`After : Yes! Its Polluted`

### 🔥 Proof of Fix (PoF) *

Before:

![image](https://user-images.githubusercontent.com/64132745/100344962-a0772800-3007-11eb-9805-9b51d3dd9dfa.png)

After:

![image](https://user-images.githubusercontent.com/64132745/100345009-b389f800-3007-11eb-814c-b3de918eb94e.png)


### 👍 User Acceptance Testing (UAT)

After fix, functionality is unaffected.
